### PR TITLE
Add Vettabase, category MariaDB

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -205,6 +205,13 @@ url = https://planet-beta-pluto.oursqlcommunity.org/
   twitter = solarwinds
   #email to be completed...
 
+[com_vettabase]
+  title = Vettabase
+  link = https://vettabase.com/blog
+  feed = https://vettabase.com/blog/category/mariadb/feed
+  twitter = https://twitter.com/vettabase
+  email = hello@vettabase.com
+
 #[com_]
 #  title = 
 #  link = 


### PR DESCRIPTION
With this PR I'm adding Vettabase Ltd blog, category: MariaDB.
We also have a category for MySQL (just replace "mariadb" with "mysql" in the URL) but I don't know if adding multiple categories is possible, or how to do that.