### PR TITLE
Added ftisiot blog for MySQL

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -525,6 +525,12 @@ url = https://planet.oursqlcommunity.org/
 #  feed = https://federico-razzoli.com/category/mysql-and-mariadb/feed
 #  twitter = FedericoRazzol1
 
+[perso_ftisiot_filtered]
+  title = Francesco Tisiot Blog
+  link = https://ftisiot.net/
+  feed = https://siftrss.com/f/gKqzWlGR93
+  twitter = ftisiot
+
 [perso_gabi.dev]
   title = gabi.dev
   link = https://gabi.dev/

--- a/planet.ini
+++ b/planet.ini
@@ -528,7 +528,8 @@ url = https://planet.oursqlcommunity.org/
 [perso_ftisiot_filtered]
   title = Francesco Tisiot Blog
   link = https://ftisiot.net/
-  feed = https://siftrss.com/f/gKqzWlGR93
+  feed = https://siftrss.com/f/JzZZ3q9xxnM
+  # Using siftrss.com to filter my blog posts (  https://ftisiot.net/posts/index.xml) including MySQL in the title
   twitter = ftisiot
 
 [perso_gabi.dev]


### PR DESCRIPTION
Added RSS feed for ftisiot.net content.

The RSS feed is using siftrss.com and pointing to the syndicated content in dev.to (better filtering options)
