### PR TITLE
Add ReliaDB blog (MySQL/MariaDB DBA consulting)

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -413,6 +413,11 @@ url = https://planet.oursqlcommunity.org/
   feed = https://siftrss.com/f/YKqo1wd3l1Q
   twitter = readysetio
 
+[com_reliadb]
+  title = ReliaDB
+  link = https://reliadb.com/blog/
+  feed = https://reliadb.com/feed-mysql.xml
+
 [com_releem]
   title = Releem Blog
   link = https://releem.com/blog/


### PR DESCRIPTION
MySQL & MariaDB focused DBA consulting blog at reliadb.com/blog/

Content: MySQL upgrade guides, MariaDB-to-Aurora migration series, InnoDB internals, EXPLAIN optimization.

Feed is category-filtered (MySQL/MariaDB only — PostgreSQL posts excluded).