### PR TITLE
Add datamcp MySQL and MCP feed

### DIFF
--- a/planet.ini
+++ b/planet.ini
@@ -216,6 +216,13 @@ url = https://planet.oursqlcommunity.org/
   feed = https://www.continuent.com/feeds/blog
   twitter = Continuent
 
+[com_datamcp]
+  title = datamcp — MySQL and MCP Notes
+  link = https://datamcp.app/blog
+  feed = https://datamcp.app/blog/mysql-feed.xml
+  github = mironovisa
+  email = hello@datamcp.app
+
 # Needs to end with _filtered for filtering icon.
 [com_dbi_filtered]
   # Original feed: https://www.dbi-services.com/blog/feed/


### PR DESCRIPTION
Adds a dedicated MySQL-only RSS feed from datamcp.

Feed: https://datamcp.app/blog/mysql-feed.xml
Blog: https://datamcp.app/blog
Public contact: https://github.com/mironovisa
Private contact: hello@datamcp.app

The feed currently contains two technical MySQL articles: a restricted-account Cursor setup guide and a comparison of MySQL MCP server deployment options. It excludes the site's PostgreSQL and OpenAPI content, following the category-feed requirement for mixed-topic blogs.

Validation completed before submission:
- live feed returns HTTP 200
- Content-Type is application/rss+xml
- XML validates successfully
- every item is categorized MySQL